### PR TITLE
security: disable postinstall/lifecycle scripts via .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the **Business Links** panel for Grafana are documented i
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Project Updates
+
+- Added `.npmrc` with `ignore-scripts=true` to disable lifecycle scripts and mitigate supply-chain attack risk.
+
 ## [2.6.0] - 2025-10-29
 
 ### Project Updates


### PR DESCRIPTION
## Why

Lifecycle scripts (`postinstall`, `prepare`, etc.) run arbitrary code during `npm install` and are
a common supply-chain attack vector.

## What changed

- Added `.npmrc` with `ignore-scripts=true`

## Notes

No dependencies in `package-lock.json` declare lifecycle scripts, so existing installs are
unaffected.

## References

- [npm docs](https://docs.npmjs.com/cli/v10/using-npm/scripts#a-note-on-a-common-anti-pattern)

## Test plan

- [ ] `npm install` completes successfully with `.npmrc` in place