### PR TITLE
chore: migrate CI workflows to plugin-ci-workflows v8.0.0 (GATB)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ permissions: {}
 jobs:
   cd:
     name: CD
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
     permissions:
       contents: write
       id-token: write

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main # zizmor: ignore[unpinned-uses]
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.0
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Migrates CI/CD workflows to `plugin-ci-workflows` v8.0.0, which introduces GATB (GitHub App Token Broker) for short-lived token authentication.

## Changes
- Bump `plugin-ci-workflows` ref from current version to `ci-cd-workflows/v8.0.0` (pinned to commit SHA `a9583870`)

## Why
Migrating to v8 is mandatory. Older versions will stop working once the long-lived GitHub App token is revoked.

## Related
A paired PR in `deployment_tools` will add the GATB configuration for repos that need it (docs publishing to website, stamp-changelog token).

See the [migration guide](https://github.com/grafana/grafana-catalog-team/blob/main/docs/plugins-ci-github-actions/070-gatb-migration.md) for details.