### PR TITLE
ci: add check-changelog job to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
   cd:
     name: CD
     needs: check-changelog
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
     permissions:
       attestations: write
       contents: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,13 +23,44 @@ on:
 permissions: {}
 
 jobs:
+  check-changelog:
+    name: Check changelog
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - name: Verify CHANGELOG.md has no [Unreleased] section
+        run: |
+          UNRELEASED_LINE=$(grep -n "^## \[Unreleased\]" CHANGELOG.md | head -1 | cut -d: -f1)
+          RELEASE_LINE=$(grep -n "^## \[[0-9]" CHANGELOG.md | head -1 | cut -d: -f1)
+
+          # No [Unreleased] section — nothing to check
+          if [ -z "$UNRELEASED_LINE" ]; then
+            exit 0
+          fi
+
+          # [Unreleased] is below the latest release — fine
+          if [ -n "$RELEASE_LINE" ] && [ "$UNRELEASED_LINE" -gt "$RELEASE_LINE" ]; then
+            exit 0
+          fi
+
+          VERSION=$(jq -r '.version' package.json)
+          echo "Error: CHANGELOG.md contains an [Unreleased] section."
+          echo "A released version is required and must match package.json (${VERSION})."
+          exit 1
+
   cd:
     name: CD
+    needs: check-changelog
     uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.0
     permissions:
+      attestations: write
       contents: write
       id-token: write
-      attestations: write
+      pull-requests: read
     with:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   ci:
     name: CI
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.0
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.1
     permissions:
       contents: read
       id-token: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Project Updates
 
 - Added `.npmrc` with `ignore-scripts=true` to disable lifecycle scripts and mitigate supply-chain attack risk.
+- Added pre-flight changelog validation to publish workflow.
 
 ## [2.6.0] - 2025-10-29
 


### PR DESCRIPTION
### CI/CD

- `publish.yml`: Add `check-changelog` pre-flight validation job before `cd` — verifies the changelog is already stamped before proceeding.
  Also adds `pull-requests: read` permission to the `cd` job and reorders permissions alphabetically.

## Test plan

- [ ] Trigger publish on a branch with a stamped `CHANGELOG.md` — workflow passes
- [ ] Trigger publish on a branch with an `[Unreleased]` section still present — workflow fails with a clear error
- [ ] Confirm the `cd` job runs after the changelog check passes