### PR TITLE
chore: align playwright config, add E2E.md, add local dev scripts

### DIFF
--- a/E2E.md
+++ b/E2E.md
@@ -1,0 +1,21 @@
+# E2E
+
+## Installation
+
+Install chromium with `npx playwright install` or `npm run test:e2e:install`.
+
+If you are unable to install playwright browsers and the installation hangs indefinitely, you can install your own
+browser and run `test:e2e:local:chrome:debug` (on *nix) for local playwright development to debug via the --ui or
+--debug flags.
+See playwright [channel docs](https://playwright.dev/docs/browsers#google-chrome--microsoft-edge) for running tests
+against other locally installed browsers.
+
+## Examples
+
+Check for flake with traces against local chrome:
+
+* `npm run test:e2e:local:chrome -- --repeat-each=10 --trace=on`
+
+Set workers (--maxWorkers 4)
+
+* `npm run test:e2e:local:chrome -- --maxWorkers 1 --repeat-each=10 --trace=on`

--- a/package.json
+++ b/package.json
@@ -85,8 +85,13 @@
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4 --coverage",
     "test:e2e": "npx playwright test",
+    "test:e2e:10x": "npx playwright test --repeat-each=10",
+    "test:e2e:install": "playwright install chromium",
     "test:e2e:dev": "npx playwright test --ui",
     "test:e2e:docker": "docker compose --profile e2e up --exit-code-from test",
+    "test:e2e:debug": "npx playwright test --debug -x --trace on",
+    "test:e2e:local:chrome": "PLAYWRIGHT_CHANNEL=chrome playwright test",
+    "test:e2e:local:chrome:debug": "PLAYWRIGHT_CHANNEL=chrome playwright test --debug --trace on",
     "typecheck": "tsc --noEmit",
     "upgrade": "npm upgrade --save"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   /**
    * Number of retry.
    */
-  retries: 0,
+  retries: 1,
 
   /**
    * Number of workers.
@@ -40,6 +40,13 @@ export default defineConfig({
      * Base URL to use in actions like `await page.goto('/')`.
      */
     baseURL: process.env.GRAFANA_URL || 'http://localhost:3000',
+
+    /**
+     * Browser channel to launch (e.g. `chrome` to use a locally installed Google Chrome).
+     * Set `PLAYWRIGHT_CHANNEL=chrome` to run against system Chrome and skip the bundled Chromium download.
+     * Left undefined in CI/Docker so the bundled Chromium is used. See https://playwright.dev/docs/browsers#google-chrome--microsoft-edge.
+     */
+    channel: process.env.PLAYWRIGHT_CHANNEL || undefined,
 
     /**
      * Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer.


### PR DESCRIPTION
Fans out improvements from grafana/business-text#90:

- `playwright.config.ts`: set `retries: 1` (was 0), add `channel` env-gate so `PLAYWRIGHT_CHANNEL=chrome` uses a locally installed browser
- `E2E.md`: new contributor guide for running/debugging E2E tests locally
- `package.json`: add `test:e2e:install`, `test:e2e:10x`, `test:e2e:debug`, `test:e2e:local:chrome`, `test:e2e:local:chrome:debug` scripts

Ref: https://github.com/grafana/business-text/pull/90