### PR TITLE
chore(ci/cd): Remove attestation prop from newest ci/cd workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,5 @@ jobs:
       branch: ${{ github.event.inputs.branch }}
       environment: ${{ github.event.inputs.environment }}
       docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
-      attestation: true
       signature-type: community
       run-playwright: false


### PR DESCRIPTION
Removing the property as the feature was removed from the workflow and this fails publishing